### PR TITLE
Fix stack overflow whichcache

### DIFF
--- a/lib/libgtkwave/src/gw-ghw-loader.c
+++ b/lib/libgtkwave/src/gw-ghw-loader.c
@@ -449,6 +449,8 @@ static void build_hierarchy_array(GwGhwLoader *self,
 
         t = build_hierarchy_type(self, arr->sa.el, name, sig);
 
+        g_free(name);
+
         if (*res != NULL)
             (*res)->next = t;
         *res = t;


### PR DESCRIPTION
Changes in gw-ghw-loader:
 - Remove recursion from `incinerate_whichcache_tree` using GPtrArray 
 - Fix a memory leak in build_hierarchy_array (memory can be freed during loading)

The tree in `incinerate_whichcache_tree` can be very deep, which lead to stack overflows in this function.  For example, in one of my ghw files (that I unfortunately can't share), `n_pending` reaches up to 786k. The deep tree might be related to having large signals, which are converted to many single-bit signals with very similar names. I've replaced the (elegant) recursive implementation with an iterative function that uses a dynamic GPtrArray on the heap to store the pending nodes. This avoids the stack overflow while preserving the functionality.